### PR TITLE
Update glazed list link

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Library | Description | License | Latest Version
 [RxSwing](https://github.com/ReactiveX/RxSwing) | RxJava bindings for Swing | Apache 2.0 | 0.27.0 / Sep 17, 2016
 [Zircon](https://github.com/Hexworks/zircon) | Text GUI library (for game developers) | MIT | 2017.3.1 / Oct 8, 2017
 [JGoodies](http://www.jgoodies.com/downloads/libraries/) | Libraries: Animation, Binding, Common, Forms, Looks, and Validation | Commercial | 10 Oct, 2017
-[Glazed Lists](http://www.glazedlists.com/) | Implementation of List suitable for using as data model for Swing components | LGPL/MPL | 1.11.0 / 10 Jan, 2018
+[Glazed Lists](https://github.com/glazedlists/glazedlists) | Implementation of List suitable for using as data model for Swing components | LGPL/MPL | 1.11.0 / 10 Jan, 2018
 [FriceEngine](https://github.com/icela/FriceEngine) | JVM game engine based on Swing/JavaFX | Affero GPL | 1.8.3 / 21 Jan, 2018
 [SystemTray](https://github.com/dorkbox/SystemTray) | Cross-platform SystemTray support for Swing/AWT | Apache 2.0 | 3.17 / Nov 3, 2018
 [gritty](https://code.google.com/archive/p/gritty/) | Swing terminal widget  | LGPL | 0.02 / Apr 17, 2007


### PR DESCRIPTION
Old website seems to be not anymore available.

Tutorial is here: https://glazedlists.github.io/glazedlists-tutorial/